### PR TITLE
Fix duplicate docblocks

### DIFF
--- a/src/Form/GeoWallSettingsForm.php
+++ b/src/Form/GeoWallSettingsForm.php
@@ -20,18 +20,12 @@ final class GeoWallSettingsForm extends ConfigFormBase {
    *
    * @var \Drupal\Core\Path\PathValidatorInterface
    */
-  /**
-   * Path validator service.
-   */
   protected PathValidatorInterface $pathValidator;
 
   /**
    * Path matcher service.
    *
    * @var \Drupal\Core\Path\PathMatcherInterface
-   */
-  /**
-   * Path matcher service.
    */
   protected PathMatcherInterface $pathMatcher;
 


### PR DESCRIPTION
## Summary
- remove duplicate docblocks for `$pathValidator` and `$pathMatcher`

## Testing
- `php -l src/Form/GeoWallSettingsForm.php` *(fails: `php` command not found)*