### PR TITLE
Fix invalid cache context service name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ GeoWall assumes the `CF-IPCountry` value is reliable and does not verify that re
 
 ## Caching
 
-GeoWall adds a custom cache context (`geowall.geo_access`) so that Drupal's page cache and CDNs can vary on whether a visitor is allowed or disallowed. Make sure upstream caches respect the `Vary` header to avoid serving restricted content to the wrong audience.
+GeoWall adds a custom cache context (`geowall_geo_access`) so that Drupal's page cache and CDNs can vary on whether a visitor is allowed or disallowed. Make sure upstream caches respect the `Vary` header to avoid serving restricted content to the wrong audience.
 
 ## Benefits
 

--- a/geowall.services.yml
+++ b/geowall.services.yml
@@ -3,7 +3,7 @@ services:
     class: Drupal\geowall\GeoWallRestrictionChecker
     arguments: ['@config.factory', '@path.matcher', '@current_route_match', '@request_stack']
 
-  cache_context.geowall.geo_access:
+  cache_context.geowall_geo_access:
     class: Drupal\geowall\Cache\Context\GeoAccessCacheContext
     arguments: ['@geowall.restriction_checker', '@request_stack']
     tags:

--- a/src/EventSubscriber/GeoWallResponseSubscriber.php
+++ b/src/EventSubscriber/GeoWallResponseSubscriber.php
@@ -46,7 +46,7 @@ final class GeoWallResponseSubscriber implements EventSubscriberInterface {
       if ($this->checker->isPathPotentiallyRestricted($request)) {
         $response->headers->set('Vary', 'CF-IPCountry', FALSE);
         $metadata = $response->getCacheableMetadata();
-        $metadata->addCacheContexts(['geowall.geo_access']);
+        $metadata->addCacheContexts(['geowall_geo_access']);
       }
     }
   }


### PR DESCRIPTION
## Summary
- rename cache context to `geowall_geo_access`
- update event subscriber and README

## Testing
- `git status --short`