### PR TITLE
Fix ConfigFormBase constructor injection

### DIFF
--- a/src/Form/GeoWallSettingsForm.php
+++ b/src/Form/GeoWallSettingsForm.php
@@ -4,6 +4,7 @@ namespace Drupal\geowall\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Path\PathValidatorInterface;
 use Drupal\Core\Path\PathMatcherInterface;
@@ -32,8 +33,8 @@ final class GeoWallSettingsForm extends ConfigFormBase {
   /**
    * Constructs the settings form.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, MessengerInterface $messenger, PathValidatorInterface $path_validator, PathMatcherInterface $path_matcher) {
-    parent::__construct($config_factory, $messenger);
+  public function __construct(ConfigFactoryInterface $config_factory, TypedConfigManagerInterface $typed_config_manager, MessengerInterface $messenger, PathValidatorInterface $path_validator, PathMatcherInterface $path_matcher) {
+    parent::__construct($config_factory, $typed_config_manager, $messenger);
     $this->pathValidator = $path_validator;
     $this->pathMatcher = $path_matcher;
   }
@@ -44,6 +45,7 @@ final class GeoWallSettingsForm extends ConfigFormBase {
   public static function create(ContainerInterface $container): static {
     return new static(
       $container->get('config.factory'),
+      $container->get('config.typed'),
       $container->get('messenger'),
       $container->get('path.validator'),
       $container->get('path.matcher')


### PR DESCRIPTION
## Summary
- pass TypedConfigManagerInterface into `GeoWallSettingsForm` constructor
- update factory method to use `config.typed`

## Testing
- `git show --stat`
